### PR TITLE
Add `Configuration` section to readme, UI dropdown config options, and fix redis container data persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ LETSENCRYPT_EMAIL=mail@example.org
 
 ### Configuration
 
-All the config options and their defaults can be found here: https://github.com/timvisee/send/blob/master/server/config.js.
+All the config options and their defaults can be found here: https://github.com/timvisee/send/blob/master/server/config.js
 
 Config options expecting array values (e.g. `EXPIRE_TIMES_SECONDS`, `DOWNLOAD_COUNTS`) are parsed as CSV, and the first entry is the default.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Send in Docker compose
+
 This repository provides a basic Docker compose configuration to host a public
 [Send](https://gitlab.com/timvisee/send) instance on your own domain.
 
@@ -15,15 +16,19 @@ This is configurable in your [`.env`](.env.example) file.
 
 See [docker-compose.yaml](./docker-compose.yaml).
 
-### Usage
+*Note: for plain Docker usage without Compose, see: https://github.com/timvisee/send/blob/master/docs/docker.md*
 
-1. Install Docker with Docker Compose https://get.docker.com/
-2. Clone this repository `git clone https://github.com/timvisee/send-docker-compose`
-3. Run `cp .env.example .env` and configure it (see [example](#example-env))
-4. Run `docker-compose up`
-5. Visit your domain
+## Usage
 
-### Example .env
+1. Install Docker and Docker Compose on your system: https://get.docker.com/
+2. Clone this repository `git clone https://github.com/timvisee/send-docker-compose && cd send-docker-compose`
+3. Run `cp .env.example .env` and edit `.env` and `docker-compose.yaml` to setup your configuration (see [example](#example-env))
+4. Run `docker-compose up` to start the containers (add `-d` to start it in the background)
+5. Wait 30sec for it to start, then visit your domain verify the UI is up and running, e.g. `https://send.example.com`
+
+<img src="https://i.imgur.com/eyvrWAP.png" alt="Screenshot of succesfully running Send UI" width="450px"/>
+
+## Example .env
 
 ```bash
 # Docker image to use for Send
@@ -32,23 +37,25 @@ See [docker-compose.yaml](./docker-compose.yaml).
 DOCKER_SEND_IMAGE=registry.gitlab.com/timvisee/send:latest
 
 # Host to expose Send on
-HOST=send.example.org
+HOST=send.example.com
 
 # Base URL for Send
-SEND_BASE_URL=https://send.example.org
+SEND_BASE_URL=https://send.example.com
 
 # Optional: for LetsEncrypt SSL, same as HOST
-LETSENCRYPT_HOST=
+LETSENCRYPT_HOST=send.example.com
 
 # Optional: for LetsEncrypt SSL, your email address
-LETSENCRYPT_EMAIL=mail@example.org
+LETSENCRYPT_EMAIL=ssl@send.example.com
 ```
 
-### Configuration
+## Configuration
 
 All the config options and their defaults can be found here: https://github.com/timvisee/send/blob/master/server/config.js
 
-Config options expecting array values (e.g. `EXPIRE_TIMES_SECONDS`, `DOWNLOAD_COUNTS`) are parsed as CSV, and the first entry is the default.
+For more documentation about the config options available and their defaults, see: https://github.com/timvisee/send/blob/master/docs/docker.md
+
+Config options expecting array values (e.g. `EXPIRE_TIMES_SECONDS`, `DOWNLOAD_COUNTS`) should be set as bare comma separated values, and the first entry is used as the default.
 
 Other options should be set as unquoted strings, integers, booleans, etc., for example:
 ```yaml
@@ -60,7 +67,7 @@ services:
     environment:
       ...
 
-      # strings numbers, bools, etc. shoul all be set as bare unquoted values
+      # strings numbers, bools, etc. should all be set as bare unquoted values
       - BASE_URL=https://send.example.com
       - DHPARAM_GENERATION=false
       - MAX_DOWNLOADS=250000
@@ -72,10 +79,10 @@ services:
       - MAX_EXPIRE_SECONDS=31536000
       - DEFAULT_EXPIRE_SECONDS=86400
 
+      # size values are are in bytes, e.g. 10GB * 1024*1024*1024 = 10,747,904,000 bytes
+      - MAX_FILE_SIZE=10747904000
+
       # array configs are set as CSV (first entry is the default for the UI dropdown)
       - EXPIRE_TIMES_SECONDS=86400,3600,86400,604800,2592000,31536000,157680000
       - DOWNLOAD_COUNTS=10,1,2,5,10,15,25,50,100,1000,10000,100000,250000
-      
-      # size values are are in bytes, e.g. 10GB * 1024*1024*1024 = 10,747,904,000 bytes
-      - MAX_FILE_SIZE=10747904000
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ See [docker-compose.yaml](./docker-compose.yaml).
 
 <img src="https://i.imgur.com/eyvrWAP.png" alt="Screenshot of succesfully running Send UI" width="450px"/>
 
+*Note: the server will autostart on boot (to disable, change all the `restart: always` lines to `restart: on-failure`)*
+
 ## Example .env
 
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,6 @@ services:
   
   redis:
     image: 'redis:alpine'
-    command: redis-server --appendonly yes
     restart: always
     volumes:
       - send-redis:/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - proxy-certs:/etc/nginx/certs:ro
       - proxy-vhost:/etc/nginx/vhost.d
       - proxy-html:/usr/share/nginx/html
+  
   proxy-letsencrypt:
     image: 'jrcs/letsencrypt-nginx-proxy-companion'
     restart: always
@@ -27,6 +28,7 @@ services:
       - proxy-certs:/etc/nginx/certs
       - proxy-vhost:/etc/nginx/vhost.d
       - proxy-html:/usr/share/nginx/html
+  
   send:
     image: '${DOCKER_SEND_IMAGE}'
     restart: always
@@ -56,14 +58,16 @@ services:
       # - S3_USE_PATH_STYLE_ENDPOINT=true
 
       # To customize upload limits
-      # - ANON_MAX_EXPIRE_SECONDS=604800
-      # - MAX_EXPIRE_SECONDS=604800
-      # - ANON_MAX_DOWNLOADS=20
-      # - MAX_DOWNLOADS=20
-      # - ANON_MAX_FILE_SIZE=2684354560
+      # - EXPIRE_TIMES_SECONDS=3600,86400,604800,2592000,31536000
+      # - DEFAULT_EXPIRE_SECONDS=3600
+      # - MAX_EXPIRE_SECONDS=31536000
+      # - DOWNLOAD_COUNTS=1,2,5,10,15,25,50,100,1000
+      # - MAX_DOWNLOADS=1000
       # - MAX_FILE_SIZE=2684354560
+  
   redis:
     image: 'redis:alpine'
+    command: redis-server --appendonly yes
     restart: always
     volumes:
       - send-redis:/data


### PR DESCRIPTION
Fixes: https://github.com/timvisee/send/issues/33
Related: https://github.com/timvisee/send/pull/34

- [x] Add `EXPIRE_TIMES_SECONDS` and `DOWNLOAD_COUNTS` options to setup UI dropdown limit options
- [x] Remove unused/outdated config options (e.g. `ANON_` prefixed options)
- [x] Add section to README explaining common configuration gotchas + link to Docker config for more details
- [x] ~~Fix redis container mounting data volume but not saving any data to disk by adding `--appendonly yes` option~~
- [x] Replace `send.example.org` host examples with `send.example.com` for consistency with rest of the docs